### PR TITLE
Fix repository urls on README

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,9 +4,9 @@ This is the loader application that creates the data file "core.json" for http:/
 
 ## Process
 
-Each release of .NET is a collection of repositories. The list for each release is managed through the [dotnet/core](https://github.com/core) repository and for each see the [/releases](https://github.com/dotnet/core/releases) section.
+Each release of .NET is a collection of repositories. The list for each release is managed through the [dotnet/core](https://github.com/dotnet/core) repository and for each see the [/releases](https://github.com/dotnet/core/releases) section.
 
-1. The loader application first loads all of the releases for [dotnet/core](https://github.com/core/releases) ordered by newest -> oldest.
+1. The loader application first loads all of the releases for [dotnet/core](https://github.com/dotnet/core/releases) ordered by newest -> oldest.
 1. For each release the **tag** of the current release and the **tag** of the previous release are used to retrieve the commits using the GitHub API : `https://api.github.com/repos/{owner}/{repo}/compare/{fromRelease}...{toRelease}`
 1. Each commit is inspected to create the data model using the `TallyCommits` method.
     1. A `Contributor` object is created if needed


### PR DESCRIPTION
Hey :wave:

The URLs on the README address the wrong destination.