### PR TITLE
Bump package version.

### DIFF
--- a/Tests/dotnetthanks-loader.Tests.csproj
+++ b/Tests/dotnetthanks-loader.Tests.csproj
@@ -15,7 +15,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="coverlet.collector" Version="10.0.0">
+    <PackageReference Include="coverlet.collector" Version="10.0.1">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>


### PR DESCRIPTION
This pull request contains a minor update to the test project dependencies. The `coverlet.collector` package has been updated to a newer patch version.

- Dependency update:
  * Upgraded the `coverlet.collector` NuGet package from version `10.0.0` to `10.0.1` in `Tests/dotnetthanks-loader.Tests.csproj` for improved test coverage tooling.