### PR TITLE
CFS: onboard thanks-data build pipeline to internal NuGet feed

### DIFF
--- a/NuGet.config
+++ b/NuGet.config
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+	<packageSources>
+		<clear />
+		<add key="dotnetsite" value="https://pkgs.dev.azure.com/devdiv/OnlineServices/_packaging/dotnetsite/nuget/v3/index.json" />
+	</packageSources>
+	<packageSourceMapping>
+		<packageSource key="dotnetsite">
+			<package pattern="*" />
+		</packageSource>
+	</packageSourceMapping>
+</configuration>

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -26,6 +26,10 @@ resources:
 extends:
   template: v1/1ES.Official.PipelineTemplate.yml@1ESPipelineTemplates
   parameters:
+    sdl:
+      policies:
+        cfsClean:
+          enabled: true
     pool:
       name: AzurePipelines-EO
       image: 1ESPT-Windows2022

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,6 +1,6 @@
 ---
 variables:
-  BuildParameters.RestoreBuildProjects: '**/*.csproj'
+  BuildParameters.RestoreBuildProjects: "**/*.csproj"
   BuildConfiguration: release
   BuildPlatform: anycpu
   Codeql.Enabled: true
@@ -8,7 +8,7 @@ variables:
 trigger:
   branches:
     include:
-      - '*'
+      - "*"
   batch: true
 
 name: $(date:yyyyMMdd)$(rev:.r)
@@ -41,8 +41,8 @@ extends:
             templateContext:
               outputs:
                 - output: pipelineArtifact
-                  displayName: 'Publish Artifacts'
-                  artifactName: 'website-thanks-data'
+                  displayName: "Publish Artifacts"
+                  artifactName: "website-thanks-data"
                   targetPath: $(build.artifactstagingdirectory)
             steps:
               - checkout: self
@@ -51,15 +51,22 @@ extends:
                 inputs:
                   version: 10.x
                   includePreviewVersions: true
+              - task: NuGetAuthenticate@1
+                displayName: NuGet Authenticate
               - task: DotNetCoreCLI@2
                 displayName: Build
                 inputs:
+                  command: build
                   projects: $(BuildParameters.RestoreBuildProjects)
                   arguments: --configuration $(BuildConfiguration)
+                  feedsToUse: config
+                  nugetConfigPath: NuGet.config
               - task: DotNetCoreCLI@2
-                displayName: 'Publish'
+                displayName: "Publish"
                 inputs:
                   command: publish
                   publishWebProjects: false
-                  arguments: '--configuration $(BuildConfiguration) --output $(Build.ArtifactStagingDirectory)'
+                  arguments: "--configuration $(BuildConfiguration) --output $(Build.ArtifactStagingDirectory)"
                   zipAfterPublish: true
+                  feedsToUse: config
+                  nugetConfigPath: NuGet.config

--- a/pipelines/scheduled/generate-core-data.yml
+++ b/pipelines/scheduled/generate-core-data.yml
@@ -16,7 +16,7 @@ schedules:
 resources:
   pipelines:
     - pipeline: dotnetwebsite
-      source: 'dotnet-website-main'
+      source: "dotnet-website-main"
   repositories:
     - repository: self
       type: git
@@ -30,6 +30,10 @@ resources:
 extends:
   template: v1/1ES.Official.PipelineTemplate.yml@1ESPipelineTemplates
   parameters:
+    sdl:
+      policies:
+        cfsClean:
+          enabled: true
     pool:
       name: AzurePipelines-EO
       image: 1ESPT-Windows2022
@@ -38,17 +42,17 @@ extends:
       - ES365AIMigrationTooling
     stages:
       - stage: thanks_data
-        displayName: 'Generate Thanks Data Stage'
+        displayName: "Generate Thanks Data Stage"
         jobs:
           - job: ProcessThanksData
-            displayName: 'Generate .NET Thanks Data'
+            displayName: "Generate .NET Thanks Data"
             timeoutInMinutes: 1440
             cancelTimeoutInMinutes: 5
             variables:
-              PREPARATION_SUCCEEDED: 'false'
-              HAS_CORE_JSON: 'false'
-              CORE_JSON_PATH: ''
-              BRANCH_NAME: ''
+              PREPARATION_SUCCEEDED: "false"
+              HAS_CORE_JSON: "false"
+              CORE_JSON_PATH: ""
+              BRANCH_NAME: ""
             steps:
               - checkout: self
                 clean: true
@@ -56,17 +60,17 @@ extends:
               - task: UseDotNet@2
                 displayName: Install .NET 10
                 inputs:
-                  packageType: 'sdk'
-                  version: '10.x'
+                  packageType: "sdk"
+                  version: "10.x"
 
               - task: Bash@3
-                displayName: 'Prepare .NET Thanks Data Tool'
+                displayName: "Prepare .NET Thanks Data Tool"
                 env:
                   GITHUB_CLIENTID: $(GITHUB_CLIENTID)
                   GITHUB_CLIENTSECRET: $(GITHUB_CLIENTSECRET)
                   GITHUB_TOKEN: $(GITHUB_TOKEN)
                 inputs:
-                  targetType: 'inline'
+                  targetType: "inline"
                   script: |
                     set +e  # Don't exit on error
 
@@ -95,12 +99,12 @@ extends:
                     exit 0
 
               - task: Bash@3
-                displayName: 'Run .NET Thanks Data Tool'
+                displayName: "Run .NET Thanks Data Tool"
                 condition: eq(variables['PREPARATION_SUCCEEDED'], 'true')
                 env:
                   GITHUB_TOKEN: $(GITHUB_TOKEN)
                 inputs:
-                  targetType: 'inline'
+                  targetType: "inline"
                   script: |
                     set -euo pipefail
 
@@ -122,25 +126,25 @@ extends:
                     fi
 
               - task: Bash@3
-                displayName: 'Clone dotnet/website repository'
+                displayName: "Clone dotnet/website repository"
                 condition: eq(variables['HAS_CORE_JSON'], 'true')
                 env:
                   GITHUB_TOKEN: $(GITHUB_TOKEN)
                 inputs:
-                  targetType: 'inline'
+                  targetType: "inline"
                   script: |
                     set -euo pipefail
                     git clone https://$GITHUB_TOKEN@github.com/dotnet/website.git dotnet-website
 
               - task: Bash@3
-                displayName: 'Update Website Repository with New Thanks Data'
+                displayName: "Update Website Repository with New Thanks Data"
                 condition: eq(variables['HAS_CORE_JSON'], 'true')
                 env:
                   GITHUB_TOKEN: $(GITHUB_TOKEN)
                   BUILD_ID: $(Build.BuildId)
                   CORE_JSON_PATH: $(CORE_JSON_PATH)
                 inputs:
-                  targetType: 'inline'
+                  targetType: "inline"
                   script: |
                     set -euo pipefail
 
@@ -193,14 +197,14 @@ extends:
                     echo "Branch '$branch' created and pushed successfully"
 
               - task: Bash@3
-                displayName: 'Create PR for .NET Thanks Data Update'
+                displayName: "Create PR for .NET Thanks Data Update"
                 condition: eq(variables['HAS_CORE_JSON'], 'true')
                 env:
                   GITHUB_TOKEN: $(GITHUB_TOKEN)
                   BUILD_ID: $(Build.BuildId)
                   BRANCH_NAME: $(BRANCH_NAME)
                 inputs:
-                  targetType: 'inline'
+                  targetType: "inline"
                   script: |
                     set -euo pipefail
 


### PR DESCRIPTION
Related to this issue: https://github.com/dotnet/website/issues/9028

 Onboards the `dotnet-website-thanks-data` build pipeline (ADO pipeline ID **22809**) to the internal Azure Artifacts NuGet feed `dotnetsite`, eliminating direct calls to `api.nuget.org` during build.
 
S360 / 1ES Network Isolation flagged this pipeline with the **CFSClean** violation
- 50 hits to `api.nuget.org` from `DotNetCoreCLI@2` tasks (Kusto telemetry).

Changes
 | File | Change |
 |---|---|
 | `NuGet.config` (new) | Single source `dotnetsite` + `packageSourceMapping` to block fallback to public sources. |
 | `azure-pipelines.yml` | Add `NuGetAuthenticate@1` step; add `feedsToUse: config` + `nugetConfigPath: NuGet.config` to both `DotNetCoreCLI@2` tasks (Build + Publish). |

