### PR TITLE
Update gh token creation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -443,3 +443,5 @@ $RECYCLE.BIN/
 
 ## Repo Specific Files
 core.json
+
+*.lscache

--- a/pipelines/scheduled/generate-core-data.yml
+++ b/pipelines/scheduled/generate-core-data.yml
@@ -76,7 +76,6 @@ extends:
                       exit 0
                     }
 
-                    echo "$GITHUB_TOKEN"
                     dotnet user-secrets init
                     [ $? -ne 0 ] && handle_failure "Failed to initialize user secrets"
 
@@ -130,7 +129,7 @@ extends:
                   targetType: 'inline'
                   script: |
                     set -euo pipefail
-                    git clone https://$GITHUB_TOKEN@github.com/dotnet/website.git dotnet-website
+                    git -c http.extraheader="AUTHORIZATION: bearer $GITHUB_TOKEN" clone https://github.com/dotnet/website.git dotnet-website
 
               - task: Bash@3
                 displayName: 'Update Website Repository with New Thanks Data'
@@ -149,10 +148,10 @@ extends:
                     # Configure git
                     git config --global user.email "bot@azuredevops.com"
                     git config --global user.name "azure-pipelines"
-                    git remote set-url origin "https://$GITHUB_TOKEN@github.com/dotnet/website.git"
+                    git remote set-url origin "https://github.com/dotnet/website.git"
 
                     # Sync with remote
-                    git fetch origin main
+                    git -c http.extraheader="AUTHORIZATION: bearer $GITHUB_TOKEN" fetch origin main
                     git checkout main
                     git reset --hard origin/main
 
@@ -187,7 +186,7 @@ extends:
 
                     # Commit and push
                     git commit -m "Update .NET thanks data"
-                    git push origin "HEAD:$branch"
+                    git -c http.extraheader="AUTHORIZATION: bearer $GITHUB_TOKEN" push origin "HEAD:$branch"
 
                     echo "##vso[task.setvariable variable=BRANCH_NAME]$branch"
                     echo "Branch '$branch' created and pushed successfully"

--- a/pipelines/scheduled/generate-core-data.yml
+++ b/pipelines/scheduled/generate-core-data.yml
@@ -58,7 +58,7 @@ extends:
                 inputs:
                   packageType: 'sdk'
                   version: '10.x'
-              - template: templates/create_github_token.yml@self
+              - template: pipelines/templates/create_github_token.yml@self
               - task: Bash@3
                 displayName: 'Prepare .NET Thanks Data Tool'
                 env:

--- a/pipelines/scheduled/generate-core-data.yml
+++ b/pipelines/scheduled/generate-core-data.yml
@@ -58,7 +58,7 @@ extends:
                 inputs:
                   packageType: 'sdk'
                   version: '10.x'
-
+              - template: templates/create_github_token.yml@self
               - task: Bash@3
                 displayName: 'Prepare .NET Thanks Data Tool'
                 env:

--- a/pipelines/scheduled/generate-core-data.yml
+++ b/pipelines/scheduled/generate-core-data.yml
@@ -129,7 +129,7 @@ extends:
                   targetType: 'inline'
                   script: |
                     set -euo pipefail
-                    git -c http.extraheader="AUTHORIZATION: bearer $GITHUB_TOKEN" clone https://github.com/dotnet/website.git dotnet-website
+                    git clone https://x-access-token:$GITHUB_TOKEN@github.com/dotnet/website.git dotnet-website
 
               - task: Bash@3
                 displayName: 'Update Website Repository with New Thanks Data'
@@ -148,10 +148,10 @@ extends:
                     # Configure git
                     git config --global user.email "bot@azuredevops.com"
                     git config --global user.name "azure-pipelines"
-                    git remote set-url origin "https://github.com/dotnet/website.git"
+                    git remote set-url origin "https://x-access-token:$GITHUB_TOKEN@github.com/dotnet/website.git"
 
                     # Sync with remote
-                    git -c http.extraheader="AUTHORIZATION: bearer $GITHUB_TOKEN" fetch origin main
+                    git fetch origin main
                     git checkout main
                     git reset --hard origin/main
 
@@ -186,7 +186,7 @@ extends:
 
                     # Commit and push
                     git commit -m "Update .NET thanks data"
-                    git -c http.extraheader="AUTHORIZATION: bearer $GITHUB_TOKEN" push origin "HEAD:$branch"
+                    git push origin "HEAD:$branch"
 
                     echo "##vso[task.setvariable variable=BRANCH_NAME]$branch"
                     echo "Branch '$branch' created and pushed successfully"

--- a/pipelines/templates/create_github_token.yml
+++ b/pipelines/templates/create_github_token.yml
@@ -1,0 +1,28 @@
+steps:
+  - task: AzureCLI@2
+    displayName: "Fetch GH key"
+    inputs:
+      azureSubscription: $(azureServiceConnection)
+      scriptType: "pscore"
+      scriptLocation: "inlineScript"
+      inlineScript: |
+        $secretValue = az keyvault secret show `
+          --name $(gh_key) `
+          --vault-name $(gh_keyVaultDev) `
+          --query value -o tsv
+
+        if (-not $secretValue) {
+          throw "Failed to retrieve GitHub app private key from Key Vault."
+        }
+
+        echo "##vso[task.setVariable variable=gh_privateKey;issecret=true]$secretValue"
+  - task: PowerShell@2
+    displayName: "Fetch GitHub token"
+    inputs:
+      targetType: "filePath"
+      filePath: "scripts/gh-fetch-cred.ps1"
+      arguments: >
+        -clientId "$(gh_clientId)"
+      pwsh: true
+    env:
+      RAW_PRIVATE_KEY: $(gh_privateKey)

--- a/scripts/gh-fetch-cred.ps1
+++ b/scripts/gh-fetch-cred.ps1
@@ -1,0 +1,119 @@
+#!/usr/bin/env pwsh
+
+param(
+	[Parameter(Mandatory = $true)]
+	[string]$clientId,
+
+	[string]$rawPrivateKey = $env:RAW_PRIVATE_KEY,
+
+	[string]$Organization = "dotnet"
+)
+
+
+function ConvertTo-Base64Url {
+	param([byte[]]$Bytes)
+	return [Convert]::ToBase64String($Bytes).TrimEnd('=').Replace('+', '-').Replace('/', '_')
+}
+
+function Resolve-PrivateKeyPem {
+	param([string]$Pem)
+
+	if ([string]::IsNullOrWhiteSpace($Pem)) {
+		throw "Private key value is empty."
+	}
+
+	$normalized = $Pem.Trim()
+
+	if (($normalized.StartsWith('"') -and $normalized.EndsWith('"')) -or ($normalized.StartsWith("'") -and $normalized.EndsWith("'"))) {
+		$normalized = $normalized.Substring(1, $normalized.Length - 2)
+	}
+
+	$normalized = $normalized.Replace('\\r\\n', [Environment]::NewLine)
+	$normalized = $normalized.Replace('\\n', [Environment]::NewLine)
+	$normalized = $normalized.Replace('\\r', [Environment]::NewLine)
+
+	if ($normalized -notmatch '-----BEGIN[\s\S]+-----END') {
+		throw "Private key does not appear to be a valid PEM payload."
+	}
+
+	return $normalized
+}
+
+if (-not $rawPrivateKey) {
+	throw "Private key not provided. Ensure the pipeline variable is set and being passed correctly."
+}
+
+$resolvedPrivateKeyPem = Resolve-PrivateKeyPem -Pem $rawPrivateKey
+
+$header = ConvertTo-Base64Url ([System.Text.Encoding]::UTF8.GetBytes((ConvertTo-Json -InputObject @{
+	alg = "RS256"
+	typ = "JWT"
+} -Compress)))
+
+$payload = ConvertTo-Base64Url ([System.Text.Encoding]::UTF8.GetBytes((ConvertTo-Json -InputObject @{
+	iat = [System.DateTimeOffset]::UtcNow.AddSeconds(-10).ToUnixTimeSeconds()
+	exp = [System.DateTimeOffset]::UtcNow.AddMinutes(10).ToUnixTimeSeconds()
+	iss = $ClientId
+} -Compress)))
+
+
+try {
+	
+	$rsa = [System.Security.Cryptography.RSA]::Create()
+	$rsa.ImportFromPem($resolvedPrivateKeyPem)
+
+	$unsignedJwt = "$header.$payload"
+	$signature = ConvertTo-Base64Url ($rsa.SignData(
+		[System.Text.Encoding]::UTF8.GetBytes($unsignedJwt),
+		[System.Security.Cryptography.HashAlgorithmName]::SHA256,
+		[System.Security.Cryptography.RSASignaturePadding]::Pkcs1
+	))
+	$jwt = "$unsignedJwt.$signature"
+
+	$headers = @{
+		Authorization = "Bearer $jwt"
+		Accept = "application/vnd.github+json"
+		"X-GitHub-Api-Version" = "2022-11-28"
+		"User-Agent" = "dotnet-website-gh-fetch-cred"
+	}
+
+	$orgInstallation = Invoke-RestMethod -Uri "https://api.github.com/orgs/$Organization/installation" -Headers $headers -Method Get -ErrorAction Stop
+
+	if (-not $orgInstallation) {
+		throw "No installation found for org '$Organization'. Ensure the app is installed for that org."
+	}
+
+	$resolvedInstallationId = [string]$orgInstallation.id
+
+	Write-Host "Resolved installation id for org '$Organization': $resolvedInstallationId"
+
+	$tokenResponse = $null
+	$tokenEndpoint = "https://api.github.com/app/installations/$resolvedInstallationId/access_tokens"
+	$tokenResponse = Invoke-RestMethod -Uri $tokenEndpoint -Headers $headers -Method Post -ContentType "application/json" -Body "{}" -ErrorAction Stop
+
+	if (-not $tokenResponse.token) {
+		throw "Access token endpoint returned no token."
+	}
+
+	Write-Host "Installation token check passed."
+	Write-Host "Token expires at: $($tokenResponse.expires_at)"
+	Write-Host "##vso[task.setVariable variable=hasToken]true"
+	Write-Host "##vso[task.setVariable variable=GITHUB_TOKEN;issecret=true]$($tokenResponse.token)"
+	
+} catch {
+	$statusCode = $null
+	if ($_.Exception.Response) {
+		$statusCode = [int]$_.Exception.Response.StatusCode
+	}
+
+	if ($statusCode) {
+		Write-Host "GitHub API call failed with HTTP $statusCode."
+	} else {
+		Write-Host "GitHub API call failed: $($_.Exception.Message)"
+	}
+
+	Write-Host "##vso[task.setVariable variable=hasToken]false"
+}
+finally {
+	$rsa.Dispose()
+}

--- a/scripts/gh-fetch-cred.ps1
+++ b/scripts/gh-fetch-cred.ps1
@@ -97,7 +97,6 @@ try {
 
 	Write-Host "Installation token check passed."
 	Write-Host "Token expires at: $($tokenResponse.expires_at)"
-	Write-Host "##vso[task.setVariable variable=hasToken]true"
 	Write-Host "##vso[task.setVariable variable=GITHUB_TOKEN;issecret=true]$($tokenResponse.token)"
 	
 } catch {

--- a/scripts/gh-fetch-cred.ps1
+++ b/scripts/gh-fetch-cred.ps1
@@ -53,7 +53,7 @@ $header = ConvertTo-Base64Url ([System.Text.Encoding]::UTF8.GetBytes((ConvertTo-
 $payload = ConvertTo-Base64Url ([System.Text.Encoding]::UTF8.GetBytes((ConvertTo-Json -InputObject @{
 	iat = [System.DateTimeOffset]::UtcNow.AddSeconds(-10).ToUnixTimeSeconds()
 	exp = [System.DateTimeOffset]::UtcNow.AddMinutes(10).ToUnixTimeSeconds()
-	iss = $ClientId
+	iss = $clientId
 } -Compress)))
 
 
@@ -112,8 +112,10 @@ try {
 		Write-Host "GitHub API call failed: $($_.Exception.Message)"
 	}
 
-	Write-Host "##vso[task.setVariable variable=hasToken]false"
+	Write-Host "##vso[task.complete result=Failed;]Unable to fetch GitHub installation token."
 }
 finally {
-	$rsa.Dispose()
+	if ($rsa) {
+		$rsa.Dispose()
+	}
 }


### PR DESCRIPTION
Fixes #https://github.com/dotnet/website/issues/9098
This pull request introduces a secure and automated way to fetch and use a GitHub App installation token in the scheduled pipeline for generating core data. The main changes involve adding a new template and script to programmatically retrieve the token from Azure Key Vault, generate a JWT, obtain an installation token from GitHub, and use it for authenticated git operations. This replaces previous approaches that relied on static or less secure token handling.

**Pipeline and Security Improvements:**

* Added a new pipeline template (`pipelines/templates/create_github_token.yml`) that securely fetches the GitHub App private key from Azure Key Vault and generates a GitHub installation token using a PowerShell script.
* Introduced a new script (`scripts/gh-fetch-cred.ps1`) that generates a JWT from the private key, fetches the GitHub App installation ID, and retrieves a short-lived installation access token, which is then set as a pipeline variable.

**Pipeline Usage Updates:**

* Integrated the new `create_github_token.yml` template into the scheduled pipeline (`pipelines/scheduled/generate-core-data.yml`) to fetch and set the `GITHUB_TOKEN` variable for subsequent tasks.
* Updated all git operations in the pipeline to use the new `GITHUB_TOKEN` in the format `https://x-access-token:$GITHUB_TOKEN@github.com/...` for improved security and compatibility with GitHub Apps authentication. [[1]](diffhunk://#diff-42365121d95c909f7bf14e51b3126d8ccf1aeae1e3b2d4cd802117a0f70be920L133-R132) [[2]](diffhunk://#diff-42365121d95c909f7bf14e51b3126d8ccf1aeae1e3b2d4cd802117a0f70be920L152-R151)
* Removed an unnecessary `echo "$GITHUB_TOKEN"` statement from the pipeline to avoid accidental token exposure in logs.