### PR TITLE
Bump 1 package.

### DIFF
--- a/Tests/dotnetthanks-loader.Tests.csproj
+++ b/Tests/dotnetthanks-loader.Tests.csproj
@@ -9,7 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.6.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.7.0" />
     <PackageReference Include="xunit" Version="2.9.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>


### PR DESCRIPTION
This pull request contains a minor update to the test project dependencies. The version of the `Microsoft.NET.Test.Sdk` package has been updated to keep the project current.

- Dependency update:
  * Upgraded `Microsoft.NET.Test.Sdk` from version 18.6.0 to 18.7.0 in `dotnetthanks-loader.Tests.csproj`.