### PR TITLE
[ci] Add task 'NuGetAuthenticate'.

### DIFF
--- a/pipelines/scheduled/generate-core-data.yml
+++ b/pipelines/scheduled/generate-core-data.yml
@@ -63,6 +63,10 @@ extends:
                   packageType: 'sdk'
                   version: '10.x'
               - template: pipelines/templates/create_github_token.yml@self
+  
+              - task: NuGetAuthenticate@1
+                displayName: NuGet Authenticate
+
               - task: Bash@3
                 displayName: "Prepare .NET Thanks Data Tool"
                 env:


### PR DESCRIPTION
Fix #https://github.com/dotnet/website/issues/9180
This pull request makes a small change to the pipeline configuration by adding a NuGet authentication step before preparing the .NET tool. This ensures that any subsequent steps requiring access to private NuGet feeds will have the necessary credentials.