### PR TITLE
[ci] Reduce ci pipeline run time

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -3,7 +3,6 @@ variables:
   BuildParameters.RestoreBuildProjects: "**/*.csproj"
   BuildConfiguration: release
   BuildPlatform: anycpu
-  Codeql.Enabled: true
 
 trigger:
   branches:
@@ -27,6 +26,13 @@ extends:
   template: v1/1ES.Official.PipelineTemplate.yml@1ESPipelineTemplates
   parameters:
     sdl:
+      codeql:
+        compiled:
+          enabled: false
+      policheck:
+        enabled: false
+      sbom:
+        enabled: false
       policies:
         cfsClean:
           enabled: true


### PR DESCRIPTION
Contributes to https://github.com/dotnet/website/issues/9203
This pull request updates the Azure Pipelines configuration to adjust security and compliance tool settings. The main change is disabling several automated scanning tools in the pipeline setup.

Pipeline security and compliance configuration:

* Disabled CodeQL scanning for compiled code by setting `codeql.compiled.enabled` to `false` in the `sdl` parameters of the pipeline template.
* Disabled Policheck and SBOM (Software Bill of Materials) tools in the pipeline by setting their `enabled` parameters to `false`.
* Removed the `Codeql.Enabled` variable from the top-level pipeline variables, as it is now configured within the `sdl` parameters.