### PR TITLE
Upgrade 1ES image to 1ESPT-Windows2025

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -32,7 +32,7 @@ extends:
           enabled: true
     pool:
       name: AzurePipelines-EO
-      image: 1ESPT-Windows2022
+      image: 1ESPT-Windows2025
       os: windows
     customBuildTags:
       - ES365AIMigrationTooling

--- a/pipelines/scheduled/generate-core-data.yml
+++ b/pipelines/scheduled/generate-core-data.yml
@@ -36,7 +36,7 @@ extends:
           enabled: true
     pool:
       name: AzurePipelines-EO
-      image: 1ESPT-Windows2022
+      image: 1ESPT-Windows2025
       os: windows
     customBuildTags:
       - ES365AIMigrationTooling


### PR DESCRIPTION
Fixes https://github.com/dotnet/website/issues/9274
**Update 1ES pool image from Windows 2022 to Windows 2025**
### What
Updates the 1ES hosted pool image from 1ESPT-Windows2022 to 1ESPT-Windows2025 across all three pipeline definitions:

`azure-pipelines.yml` 
`generate-core-data.yml`
### Why
The Windows 2025 1ES image ships with a newer Azure CLI ect.