### PR TITLE
Update artifact name

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -46,7 +46,7 @@ extends:
               outputs:
                 - output: pipelineArtifact
                   displayName: "Publish Artifacts"
-                  artifactName: "website-thanks-data"
+                  artifactName: "website-thanks-data-drop"
                   targetPath: $(build.artifactstagingdirectory)
             steps:
               - checkout: self


### PR DESCRIPTION
This pull request makes a small change to the Azure Pipelines configuration by updating the artifact name for published build outputs.

* Changed the `artifactName` from `"website-thanks-data"` to `"website-thanks-data-drop"` in the `azure-pipelines.yml` file.